### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# IdentityServer3.AccessTokenValidation.Integration.AspNetCore
+
+This is middleware works with for ASP.NET Core on .Net Framework (4.6+), for .NetCore framework clients use IdentityServer4.AccessTokenValidation.AspNetCore


### PR DESCRIPTION
 to explain that IdentityServer3.AccessTokenValidation works with katana clients, against both IdentityServer3 and identityServer4
 IdentityServer4.AccessTokenValidation works with aspNetCore clients, against both IdentityServer3 and identityServer4